### PR TITLE
Make multi-arch builds

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: build
     steps:
       - uses: actions/checkout@master
@@ -17,9 +17,19 @@ jobs:
         shell: bash
         run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
         id: extract_tag_name
-      - name: Build Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          name: sslhep/rucio-client:${{ steps.extract_tag_name.outputs.imagetag }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: sslhep/rucio-client:${{ steps.extract_tag_name.outputs.imagetag }}


### PR DESCRIPTION
# Problem
Developers with Apple Silicon and presumably future Kubernetes clusters need docker images that support the ARM processors

# Approach
Update the GitHub action to build and push multi architecture docker images